### PR TITLE
use yaml.safe_load(input) not yaml.load(input)

### DIFF
--- a/vedacore/misc/checkpoint.py
+++ b/vedacore/misc/checkpoint.py
@@ -31,7 +31,7 @@ def get_open_mmlab_models():
     current_dir = os.path.dirname(__file__)
     file_path = os.path.join(current_dir, '..', 'model_zoo', 'open_mmlab.yaml')
 
-    model_urls = yaml.load(open(file_path))
+    model_urls = yaml.safe_load(open(file_path))
 
     return model_urls
 


### PR DESCRIPTION
yaml.load(input) is deprecated, use yaml.safe_load(input) instead. See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation.